### PR TITLE
Fix run amount for ++ glm_panther_lambdas()

### DIFF
--- a/src/libs/pestpp_common/SVDSolver.cpp
+++ b/src/libs/pestpp_common/SVDSolver.cpp
@@ -1399,7 +1399,7 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 				if (panther_manager) 
 				{
 					std::map<std::string, int> stats = panther_manager->get_agent_stats();
-					lmrun = stats["total"];
+					lmrun = stats["total"] - 1; // we subtract off one to account for the base run that also gets run during the Jacobian
 					panther_message.str("");
 					panther_message << "Number of connected agents to be used for lambda upgrades: " << lmrun;
 					performance_log->log_event(panther_message.str());
@@ -1443,7 +1443,13 @@ ModelRun SVDSolver::iteration_upgrd(RunManagerAbstract &run_manager, Termination
 
 						current_product = lambda_vec.size() * lambda_scale_vec.size();
 						}
+					// set the new lambda vector and lambda scale vector back to the base scenario
+					std::sort(lambda_vec.begin(), lambda_vec.end());
+					std::sort(lambda_scale_vec.begin(), lambda_scale_vec.end());
+					pest_scenario.get_pestpp_options_ptr()->set_base_lambda_vec(lambda_vec);
+					pest_scenario.get_pestpp_options_ptr()->set_lambda_scale_vec(lambda_scale_vec);
 					} 
+					
 					else 
 					{ // otherwise stick with our default
 						panther_message.str("");


### PR DESCRIPTION
The base run was not accounted for when determining the number of upgrade runs to perform when the glm_panther_lambdas option is set to true. This simple change decreases that calculated number by 1 to account for the base/last best upgrade run. Additionally, the lambda scale vector and lambda vector is properly set at the end of iteration upgrade process.